### PR TITLE
Fix typos in projects page

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -43,12 +43,12 @@ permalink: projects.html
             </div>
           </div>
 
-        <p>A local home autuomation server using <a href="https://github.com/home-assistant/core">Home Assistant</a>, controlling lights, TV, climate, cleaning functions, and several Alexa speakers. Runs on a Zigbee and MQTT network, proxied through a Cloudflare Zero-Trust tunnel.</p>
+        <p>A local home automation server using <a href="https://github.com/home-assistant/core">Home Assistant</a>, controlling lights, TV, climate, cleaning functions, and several Alexa speakers. Runs on a Zigbee and MQTT network, proxied through a Cloudflare Zero-Trust tunnel.</p>
         <p>Pulls Geolocation data from phones, weather data from Tomorrow.io, presence and motion sensor detection data, and other sensor data into a local PostgreSQL database.</p>
         <p>Lights change color temperature based on time of day and weather condition. Lights and HVAC automatically turn off based on presence detection. Connected to Alexa and Homekit proxied through local servers and Cloudflare.</p>
     </div>
     <div>
-        <h1>Personal Cloud Sever with Nextcloud</h1>
+        <h1>Personal Cloud Server with Nextcloud</h1>
         <img src="assets/Nextcloud.png"></img>
         <p>Created a personal Dropbox-like server using <a href="https://github.com/nextcloud/docker">Nextcloud</a>, running on Network Attached Storage at home. Runs on Docker, proxied through Cloudflare Zero-Trust, with Redis server for memory caching and PostgreSQL for backend.</p>
     </div>


### PR DESCRIPTION
## Summary
- fix typos on the projects page

## Testing
- `grep -n autuomation projects.html`
- `grep -n Sever projects.html`

------
https://chatgpt.com/codex/tasks/task_e_6844f89e6c488322959981aa9552b996